### PR TITLE
remove content security policy from HTTP headers

### DIFF
--- a/layouts/index.headers
+++ b/layouts/index.headers
@@ -2,7 +2,6 @@
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   X-Content-Type-Options: nosniff
   X-XSS-Protection: 1; mode=block
-  Content-Security-Policy: default-src 'self'; frame-ancestors https://jamstackthemes.dev; manifest-src 'self'; connect-src 'self'; font-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self'
   X-Frame-Options: SAMEORIGIN
   Referrer-Policy: strict-origin
   Feature-Policy: geolocation 'self'


### PR DESCRIPTION
I think this *might* fix the issue. I traced it back to the theme, which has a strict security policy that blocks the loading of scripts from unknown hosts. NetlifyCMS requires loading two scripts:

- `<script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>`
- `<script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>`

Which would throw this error in the JavaScript console:

```
Refused to load the script 'https://unpkg.com/netlify-cms@%5E2.0.0/dist/netlify-cms.js' because it violates the following Content Security Policy directive: "script-src 'self'". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback.
```

I think with a more relaxed policy, the scripts should be able to load, and the login process should be able to work (I hope). 